### PR TITLE
Changed relative URLs to absolute URLs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="doc/images/readme-header.png" alt="Polywit Logo" style="width: 75%;"/><br>
+  <img src="https://raw.githubusercontent.com/polywit/polywit/main/doc/images/readme-header.png" alt="Polywit Logo" style="width: 75%;"/><br>
 </div>
 
 -----------------
@@ -14,7 +14,7 @@ Whilst most modern execution-based validators such as wit4java and CPA-wit2test 
 ### Framework
 For a general language, the polywit implementation has the following architecture:
 <div align="center">
-  <img src="doc/images/framework-architecture.png" alt="Polywit Architecture" style="width: 75%;"/><br>
+  <img src="https://raw.githubusercontent.com/polywit/polywit/main/doc/images/framework-architecture.png" alt="Polywit Architecture" style="width: 75%;"/><br>
 </div>
 
 - The **File Processor** deals with processing of the compilation units.


### PR DESCRIPTION
# Description

README.md now have absolute URLs instead of relative URLs.

Fixes #18 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

# How Has This Been Tested?

It works correctly in this online markdown [editor](https://markdownlivepreview.com/) and also in github.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules