### PR TITLE
✨: Adding assumption output 

### DIFF
--- a/polywit/__main__.py
+++ b/polywit/__main__.py
@@ -47,9 +47,19 @@ def create_argument_parser() -> argparse.ArgumentParser:
         help='Frontend language'
     )
 
+    base_subparser = argparse.ArgumentParser(add_help=False)
+
+    # define common shared arguments
+    base_subparser.add_argument(
+        '--show-assumptions',
+        action=argparse.BooleanOptionalAction,
+        help="Shows the extracted assumptions from the witness"
+    )
+
     java_sub_parser = subparsers.add_parser(
         'java',
-        help='Use the java validator'
+        help='Use the java validator',
+        parents=[base_subparser]
     )
 
     java_sub_parser.add_argument(
@@ -77,7 +87,8 @@ def create_argument_parser() -> argparse.ArgumentParser:
 
     kotlin_sub_parser = subparsers.add_parser(
         'kotlin',
-        help='Use the kotlin validator'
+        help='Use the kotlin validator',
+        parents=[base_subparser]
     )
 
     kotlin_sub_parser.add_argument(

--- a/polywit/__main__.py
+++ b/polywit/__main__.py
@@ -52,7 +52,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
     # define common shared arguments
     base_subparser.add_argument(
         '--show-assumptions',
-        action=argparse.BooleanOptionalAction,
+        action='store_true',
         help="Shows the extracted assumptions from the witness"
     )
 

--- a/polywit/base/file_processors.py
+++ b/polywit/base/file_processors.py
@@ -7,9 +7,11 @@
 
 from abc import ABC, abstractmethod
 import os
+from typing import List, Optional
+
 import networkx as nx
 
-from polywit._typing.aliases import Position
+from polywit._typing.aliases import Position, Assumption
 
 
 class Processor(ABC):
@@ -71,7 +73,7 @@ class WitnessProcessor(Processor):
         self.witness_path = witness_path
         self.witness = None
 
-    def preprocess(self):
+    def preprocess(self) -> None:
         if self.witness is None:
             try:
                 self.witness = nx.read_graphml(self.witness_path)
@@ -80,7 +82,7 @@ class WitnessProcessor(Processor):
         # Check witness is linear
         self._check_witness_linearity()
 
-    def _check_witness_linearity(self):
+    def _check_witness_linearity(self) -> None:
         """
         Checks the witness is a linear violation witness before building validator
         """
@@ -103,11 +105,11 @@ class WitnessProcessor(Processor):
         if len(list(nx.all_simple_paths(self.witness, source=self.entry_node, target=self.violation_node))) > 1:
             raise ValueError('Witness has multiple execution paths from source to sink')
 
-    def _get_value_from_witness(self, key):
+    def _get_value_from_witness(self, key) -> Optional[str]:
         return self.witness.graph[key] if key in self.witness.graph else None
 
     @abstractmethod
-    def extract_assumptions(self):
+    def extract_assumptions(self) -> List[Assumption]:
         """
         Extracts the assumptions from the witness
         """

--- a/polywit/base/validator.py
+++ b/polywit/base/validator.py
@@ -4,7 +4,6 @@
 
  This module deals with the base building of the test harness
 """
-import shutil
 import tempfile
 from abc import ABC, abstractmethod
 from typing import List

--- a/polywit/base/validator.py
+++ b/polywit/base/validator.py
@@ -70,7 +70,8 @@ class Validator(ABC):
         self.test_harness.build_test_harness(assumptions)
         return self.test_harness.run_test_harness()
 
-    def _print_assumptions(self, assumptions: List[Assumption], position_type_map: dict[Position, str]):
+    @staticmethod
+    def _print_assumptions(assumptions: List[Assumption], position_type_map: dict[Position, str]):
         headers = ['Position', 'Value', 'Type']
         table_data = []
         for assumption in assumptions:

--- a/polywit/base/validator.py
+++ b/polywit/base/validator.py
@@ -4,12 +4,15 @@
 
  This module deals with the base building of the test harness
 """
+import shutil
 import tempfile
 from abc import ABC, abstractmethod
 from typing import List
 
+from tabulate import tabulate
+
 from polywit.base import WitnessProcessor, FileProcessor
-from polywit._typing import Assumption
+from polywit._typing import Assumption, Position
 from polywit.utils import filter_assumptions
 from polywit.base import TestHarness, PolywitTestResult
 
@@ -58,8 +61,24 @@ class Validator(ABC):
         """
         position_type_map = self.file_processor.extract_position_type_map()
         assumptions = self.witness_processor.extract_assumptions()
-        return filter_assumptions(position_type_map, assumptions)
+        assumptions = filter_assumptions(position_type_map, assumptions)
+        if self.config['show_assumptions']:
+            self._print_assumptions(assumptions, position_type_map)
+        return assumptions
 
     def execute_test_harness(self, assumptions: List[Assumption]) -> PolywitTestResult:
         self.test_harness.build_test_harness(assumptions)
         return self.test_harness.run_test_harness()
+
+    def _print_assumptions(self, assumptions: List[Assumption], position_type_map: dict[Position, str]):
+        headers = ['Position', 'Value', 'Type']
+        table_data = []
+        for assumption in assumptions:
+            position = assumption[0]
+            formatted_position = f'{position[0]}:{position[1]}'
+            value = assumption[1]
+            value_type = position_type_map[position]
+            table_data.append((formatted_position, value, value_type))
+        print('polywit: Extracted assumptions:')
+        print(tabulate(table_data, headers=headers, tablefmt="pretty"))
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ networkx~=2.8.8
 javalang~=0.13.0
 kopyt~=0.0.2
 setuptools==65.6.3
+tabulate~=0.9.0


### PR DESCRIPTION
# Description

By now adding the `--show-assumptions` flag to any of the supported frontends a nice tabular output of the extracted assumptions from the witness is shown:

```bash
polywit: v1.0.0
polywit: Extracted assumptions:
+----------+-------+------+
| Position | Value | Type |
+----------+-------+------+
|  Main:5  |   0   | int  |
+----------+-------+------+
polywit: Witness correct
```

Fixes #26 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

See above example for new functionality. Regression testing has been run to ensure without the flag it still outputs the correct answer.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules